### PR TITLE
Duplicate "Config" Fix - Line 277

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -274,7 +274,7 @@ RegisterServerEvent('mz-shrooms:server:receiveShroomsNoXP')
 AddEventHandler('mz-shrooms:server:receiveShroomsNoXP', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local quantity = math.random(Config.ShroomNoXPlow, Config.Config.ShroomNoXPhigh)
+    local quantity = math.random(Config.ShroomNoXPlow, Config.ShroomNoXPhigh)
     Player.Functions.AddItem("shroombag", quantity, false)
     TriggerClientEvent('inventory:client:ItemBox', source, QBCore.Shared.Items['shroombag'], "add", quantity)
 end)


### PR DESCRIPTION
Tiny correction for duplicate word "Config" in Config.Config.ShroomNoXPhigh on line 277, as it would fail to give you the item after bagging Shrooms when Config.mzskills = false. Changed to Config.ShroomNoXPhigh so it successfully adds item to inventory now.